### PR TITLE
Add TypeScript version of grant parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .env
 epa_runs
 ks_runs
+!ts/package.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# grant-parser-py
-Langchain Python for parsing grant PDFs and returning JSON of wanted information
+# grant-parser
+
+This repository contains two implementations for parsing grant PDFs and extracting structured information using LangChain:
+
+- **Python version** (`grant.py`)
+- **TypeScript version** (`ts/grant.ts`)
+
+Both versions load a PDF, create an in-memory vector store from embeddings, perform a similarity search for relevant pages, and then ask a language model to return JSON data describing the grant.
+
+## Python usage
 
 - embedding model **nomic-embed-text**, chat llm **gemma3**
 
-### python grant.py \<path to pdf\> \<k-value\>
+```bash
+python grant.py <path to pdf> <k-value>
+```
+
+## TypeScript usage
+
+The TypeScript project lives in the `ts/` directory. Install its dependencies with `npm install` and then run:
+
+```bash
+npx ts-node grant.ts <path to pdf> <k-value>
+```

--- a/ts/grant.ts
+++ b/ts/grant.ts
@@ -1,0 +1,55 @@
+import { parse } from "./parser";
+import { simSearch, retrieveDataFromLlm, determineSchema } from "./rag";
+import { OllamaEmbeddings } from "@langchain/community/embeddings/ollama";
+import { MemoryVectorStore } from "langchain/vectorstores/memory";
+import * as fs from "fs";
+
+const args = process.argv.slice(2);
+if (args.length < 2) {
+  console.log("Usage: ts-node grant.ts <path to pdf> <k-value>");
+  process.exit(1);
+}
+
+const filepath = args[0];
+const k = parseInt(args[1], 10);
+
+(async () => {
+  console.log("Loading PDF...");
+  const pages = await parse(filepath);
+
+  const embeddings = new OllamaEmbeddings({ model: "nomic-embed-text" });
+  const vectorStore = await MemoryVectorStore.fromDocuments(pages, embeddings);
+
+  const llmQueries: Record<string, string> = {
+    general: "What is the full name of the grant? List all projects or programs stated, including each project's name, start date, and end date.",
+    spending: "What is the total grant amount? Break down the spending into: fringe benefits, indirect costs, travel, equipment, and other. For \u201cother,\u201d provide a list of items with their names and cost. Return only valid JSON."
+  };
+
+  const vecQueries: Record<string, string> = {
+    general: "Information about the grant's official name, and the names, start and end dates of any funded projects or programs.",
+    spending: "Details about total funding, and how the grant money is allocated \u2014 including fringe benefits, indirect costs, travel, equipment, and other types of spending."
+  };
+
+  let grant: any = {};
+
+  for (const key of Object.keys(llmQueries)) {
+    console.log("Similar searching...");
+    const vecQuestion = vecQueries[key];
+    console.log("Q:", vecQuestion);
+    const context = await simSearch(vecQuestion, k, vectorStore);
+    const schema = determineSchema(key);
+    console.log("Got context");
+
+    console.log("Asking LLM...");
+    const llmQuestion = llmQueries[key];
+    console.log("Q:", llmQuestion);
+    const response = await retrieveDataFromLlm(llmQuestion, context, schema);
+    console.log("response:", response);
+
+    console.log("Updating grant json...");
+    grant = { ...grant, ...response };
+    console.log(JSON.stringify(grant));
+  }
+
+  await fs.promises.writeFile("grant.json", JSON.stringify(grant, null, 4));
+})();

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "grant-parser-ts",
+  "version": "0.1.0",
+  "description": "LangChain TypeScript for parsing grant PDFs and returning structured JSON",
+  "type": "module",
+  "main": "dist/grant.js",
+  "scripts": {
+    "start": "ts-node grant.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@langchain/community": "^0.0.17",
+    "@langchain/openai": "^0.0.10",
+    "langchain": "^0.1.0",
+    "zod": "^3.22.2",
+    "dotenv": "^16.0.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.3"
+  }
+}

--- a/ts/parser.ts
+++ b/ts/parser.ts
@@ -1,0 +1,8 @@
+import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
+import { Document } from "langchain/document";
+
+export async function parse(file: string): Promise<Document[]> {
+  const loader = new PDFLoader(file);
+  const pages = await loader.load();
+  return pages;
+}

--- a/ts/rag.ts
+++ b/ts/rag.ts
@@ -1,0 +1,89 @@
+import { MemoryVectorStore } from "langchain/vectorstores/memory";
+import { ChatOpenAI } from "@langchain/openai";
+import { PromptTemplate } from "@langchain/core/prompts";
+import { StructuredOutputParser } from "@langchain/core/output_parsers";
+import { z } from "zod";
+import * as dotenv from "dotenv";
+
+export async function simSearch(query: string, k: number, vectorStore: MemoryVectorStore): Promise<string> {
+  const docs = await vectorStore.similaritySearch(query, k);
+  let context = "";
+  for (const doc of docs) {
+    context += doc.pageContent;
+  }
+  return context;
+}
+
+export async function retrieveDataFromLlm(question: string, context: string, schema: ReturnType<typeof determineSchema>): Promise<any> {
+  dotenv.config();
+  const llm = new ChatOpenAI({
+    modelName: process.env.MODEL,
+    temperature: 0,
+    openAIApiKey: process.env.OPENAI_KEY,
+    configuration: { baseURL: process.env.OPENAI_BASE_URL }
+  });
+
+  const parser = StructuredOutputParser.fromZodSchema(schema);
+
+  const prompt = new PromptTemplate({
+    template: `You are a professional analyst specializing in grants and legal funding information. Your job is to extract structured information from legal documents.
+
+Use the context provided to answer the question. Format your output as **valid JSON** matching the structure described below.
+
+\u203c\ufe0f Important instructions:
+- ONLY report the variables stated in the format and NOTHING MORE. Do NOT report any other variables!
+- Do NOT include explanations, comments, or text before or after the JSON curly braces like \`json ... \`.
+- Return a valid JSON object only. Make sure it can be parsed with JSON.parse().
+- If a value is not found, use an empty string or an empty list.
+
+Context:
+{context}
+
+Question:
+{question}
+
+Format:
+{format_instructions}`,
+    inputVariables: ["context", "question"],
+    partialVariables: { format_instructions: parser.getFormatInstructions() },
+  });
+
+  const chain = prompt.pipe(llm).pipe(parser);
+  const response = await chain.invoke({ context, question });
+  return response;
+}
+
+export const projectSchema = z.object({
+  name: z.string().describe("Name or title of the project or program"),
+  start_date: z.string().describe("Start date of the project in MM/DD/YYYY or YYYY-MM-DD format"),
+  end_date: z.string().describe("End date of the project in MM/DD/YYYY or YYYY-MM-DD format"),
+});
+
+export const generalGrantInfoSchema = z.object({
+  grant_name: z.string().describe("The official name or title of the grant"),
+  projects: z.array(projectSchema).describe("List of projects funded by this grant, each with a name, start date, and end date"),
+});
+
+export const otherSchema = z.object({
+  obj: z.string().describe("A specific object or item receiving funding under 'other' spending"),
+  cost: z.number().describe("Cost amount allocated to this object in USD"),
+});
+
+export const spendingInfoSchema = z.object({
+  total: z.number().describe("Total amount of grant funding in USD"),
+  fringe: z.number().describe("Amount for fringe benefits such as insurance, retirement, etc."),
+  indirect: z.number().describe("Amount for indirect costs like rent, administrative overhead, and utilities"),
+  travel: z.number().describe("Amount allocated to travel-related expenses"),
+  equipment: z.number().describe("Amount allocated to equipment purchases"),
+  other: z.array(otherSchema).describe("List of other individual items or objects that received funding, with their respective cost"),
+});
+
+export function determineSchema(key: string) {
+  if (key === "general") {
+    return generalGrantInfoSchema;
+  }
+  if (key === "spending") {
+    return spendingInfoSchema;
+  }
+  return z.object({});
+}


### PR DESCRIPTION
## Summary
- create TypeScript implementation alongside Python scripts
- add TypeScript package configuration
- document how to run both versions in README

## Testing
- `python -m py_compile grant.py parser.py rag.py`