### PR TITLE
Add initial tests for parser and LLM retrieval

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,49 @@
+import json
+import os
+import importlib.util
+import sys
+from pathlib import Path
+from langchain_core.documents import Document
+from pydantic import BaseModel
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "parser", ROOT / "parser.py"
+)
+parser = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(parser)
+sys.modules['parser'] = parser
+
+class FakeLoader:
+    def __init__(self, *args, **kwargs):
+        pass
+    def lazy_load(self):
+        return [Document(page_content="content", metadata={"page":1}), Document(page_content="content2", metadata={"page":2})]
+
+def test_parse_returns_pages(monkeypatch):
+    # Patch PyPDFLoader in parser module
+    monkeypatch.setattr(parser, 'PyPDFLoader', lambda *a, **k: FakeLoader())
+    pages = parser.parse('dummy.pdf')
+    assert isinstance(pages, list)
+    assert len(pages) == 2
+    assert all(isinstance(p, Document) for p in pages)
+
+class FakeLLM:
+    def __init__(self, *args, **kwargs):
+        pass
+    def invoke(self, prompt: str):
+        return '{"foo": "bar"}'
+    __call__ = invoke
+
+class ExampleModel(BaseModel):
+    foo: str
+
+def test_retrieve_data_from_llm(monkeypatch):
+    import rag
+    monkeypatch.setattr(rag, 'ChatOpenAI', lambda *a, **k: FakeLLM())
+    result = rag.retrieve_data_from_llm('question', 'context', ExampleModel)
+    assert isinstance(result, dict)
+    json.loads(json.dumps(result))
+    assert result == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- create `tests/` directory
- add tests covering `parse()` functionality
- add tests verifying `retrieve_data_from_llm` returns valid JSON via mocking

## Testing
- `pytest -q`