### PR TITLE
Fix env init location and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,11 @@ Langchain Python for parsing grant PDFs and returning JSON of wanted information
 
 - embedding model **nomic-embed-text**, chat llm **gemma3**
 
+### Environment variables
+Create a `.env` file or export the following variables before running any script:
+
+- `MODEL` – name of the chat model used by `ChatOpenAI`
+- `OPENAI_KEY` – API key for the model
+- `OPENAI_BASE_URL` – base URL of the OpenAI endpoint
+
 ### python grant.py \<path to pdf\> \<k-value\>

--- a/rag.py
+++ b/rag.py
@@ -25,8 +25,11 @@ from pydantic import BaseModel, Field
 from typing import Dict
 from dotenv import load_dotenv
 
+# Load environment variables at import time so they are available for all
+# functions that rely on them.
+load_dotenv()
+
 def retrieve_data_from_llm(question, context, py_obj):
-    load_dotenv()
     llm = ChatOpenAI(
         model=os.getenv("MODEL"),
         temperature=0,


### PR DESCRIPTION
## Summary
- load environment variables when `rag` module is imported
- document required environment variables
- clarify README wording on env setup

## Testing
- `python -m py_compile rag.py grant.py parser.py`
