### PR TITLE
Enable multi-PDF parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ yarn install
 - embedding model **nomic-embed-text**, chat llm **gemma3**
 
 ```bash
-uv run grant.py <path to pdf> <k-value>
+uv run grant.py <path to pdf> [<additional pdfs>...] -k <k-value>
 ```
 
 ## TypeScript usage

--- a/grant.py
+++ b/grant.py
@@ -11,16 +11,26 @@ import json
 
 
 def main() -> None:
-    argparser = argparse.ArgumentParser(description="Parse a grant file (.pdf)")
-    argparser.add_argument("filepath", type=str, help="Path to the grant pdf file")
-    argparser.add_argument("k", type=int, help="# nearest neighbors to retrieve for similarity search")
+    argparser = argparse.ArgumentParser(description="Parse grant PDF files")
+    argparser.add_argument(
+        "files",
+        nargs="+",
+        help="Path(s) to one or more PDF files for the same grant",
+    )
+    argparser.add_argument(
+        "-k",
+        type=int,
+        default=4,
+        help="# nearest neighbors to retrieve for similarity search",
+    )
     args = argparser.parse_args()
 
     print("Loading PDF...")
     try:
-        pages = parse(args.filepath)
+        pages = parse(args.files)
     except Exception as e:
-        print(f"Failed to load PDF '{args.filepath}': {e}")
+        joined = ", ".join(args.files)
+        print(f"Failed to load PDF(s) '{joined}': {e}")
         return
 
     embeddings = OllamaEmbeddings(model="nomic-embed-text")

--- a/parser.py
+++ b/parser.py
@@ -1,16 +1,39 @@
 # import asyncio # async functionality in python (dynamic loading)
+from typing import Iterable, List, Union
 from langchain_community.document_loaders import PyPDFLoader
+from langchain_core.documents import Document
 
-def parse(file):
-    loader = PyPDFLoader(file)
+
+def parse(files: Union[str, Iterable[str]]) -> List[Document]:
+    """Load pages from one or more PDF files.
+
+    Parameters
+    ----------
+    files
+        A single file path or an iterable of file paths.
+
+    Returns
+    -------
+    List[Document]
+        All pages from the provided PDFs in the order they were loaded.
+    """
+
+    if isinstance(files, (str, bytes)):
+        file_list = [files]
+    else:
+        file_list = list(files)
+
     pages = []
-    # async for page in loader.alazy_load():
-    for page in loader.lazy_load():
-        pages.append(page)
-        
+    for file in file_list:
+        loader = PyPDFLoader(file)
+        for page in loader.lazy_load():
+            pages.append(page)
+
     return pages
 
 if __name__=="__main__":
-    pages = parse()
-    print(f"{pages[0].metadata}\n")
-    print(pages[0].page_content)
+    import sys
+    pages = parse(sys.argv[1:])
+    if pages:
+        print(f"{pages[0].metadata}\n")
+        print(pages[0].page_content)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,11 +23,12 @@ class FakeLoader:
         return [Document(page_content="content", metadata={"page":1}), Document(page_content="content2", metadata={"page":2})]
 
 def test_parse_returns_pages(monkeypatch):
-    # Patch PyPDFLoader in parser module
+    """parse() should return all pages from multiple PDFs."""
+    # Patch PyPDFLoader in parser module so each PDF yields two pages
     monkeypatch.setattr(parser, 'PyPDFLoader', lambda *a, **k: FakeLoader())
-    pages = parser.parse('dummy.pdf')
+    pages = parser.parse(["dummy1.pdf", "dummy2.pdf"])
     assert isinstance(pages, list)
-    assert len(pages) == 2
+    assert len(pages) == 4
     assert all(isinstance(p, Document) for p in pages)
 
 class FakeLLM:


### PR DESCRIPTION
## Summary
- support passing multiple files into `parse`
- update `grant.py` CLI to accept multiple PDF paths
- update README usage instructions
- test parsing multiple PDFs

## Testing
- `pytest -q`