### PR TITLE
Support multiple PDFs in TS parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ uv run grant.py <path to pdf> <k-value>
 The TypeScript project lives in the `ts/` directory. After installing the dependencies with Yarn, run:
 
 ```bash
-npx ts-node grant.ts <path to pdf> <k-value>
+npx ts-node grant.ts <k-value> <path to pdf> [additional pdfs...]
 ```
+
+You can provide multiple PDF files for a single grant; all pages will be loaded together.
 
 ## Environment variables
 

--- a/ts/grant.ts
+++ b/ts/grant.ts
@@ -6,16 +6,17 @@ import * as fs from "fs";
 
 const args = process.argv.slice(2);
 if (args.length < 2) {
-  console.log("Usage: ts-node grant.ts <path to pdf> <k-value>");
+  console.log("Usage: ts-node grant.ts <k-value> <path to pdf> [additional pdfs...]\n" +
+    "Example: ts-node grant.ts 3 file1.pdf file2.pdf");
   process.exit(1);
 }
 
-const filepath = args[0];
-const k = parseInt(args[1], 10);
+const k = parseInt(args[0], 10);
+const filepaths = args.slice(1);
 
 (async () => {
-  console.log("Loading PDF...");
-  const pages = await parse(filepath);
+  console.log("Loading PDFs...");
+  const pages = await parse(filepaths);
 
   const embeddings = new OllamaEmbeddings({ model: "nomic-embed-text" });
   const vectorStore = await MemoryVectorStore.fromDocuments(pages, embeddings);

--- a/ts/parser.ts
+++ b/ts/parser.ts
@@ -1,8 +1,13 @@
 import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
 import { Document } from "langchain/document";
 
-export async function parse(file: string): Promise<Document[]> {
-  const loader = new PDFLoader(file);
-  const pages = await loader.load();
-  return pages;
+export async function parse(files: string | string[]): Promise<Document[]> {
+  const fileList = Array.isArray(files) ? files : [files];
+  const allPages: Document[] = [];
+  for (const file of fileList) {
+    const loader = new PDFLoader(file);
+    const pages = await loader.load();
+    allPages.push(...pages);
+  }
+  return allPages;
 }


### PR DESCRIPTION
## Summary
- allow the TypeScript parser to combine multiple PDFs
- update grant.ts CLI arguments
- document multi-file support in README

## Testing
- `pytest -q`