### PR TITLE
Add folder argument to grant.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ uv run grant.py <path to pdf> [<additional pdfs>...] -k <k-value>
 The TypeScript project lives in the `ts/` directory. After installing the dependencies with Yarn, run:
 
 ```bash
-npx ts-node grant.ts <k-value> <path to pdf> [additional pdfs...]
+npx ts-node grant.ts <k-value> [--folder <dir> | <path to pdf> [additional pdfs...]]
 ```
 
-You can provide multiple PDF files for a single grant; all pages will be loaded together.
+You can provide multiple PDF files for a single grant, or pass `--folder` to load every PDF under a directory recursively. All pages will be loaded together.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary
- expand TypeScript CLI usage to allow `--folder` argument
- recursively load all PDFs from a directory when `--folder` is provided
- document new option in README

## Testing
- `pytest -q`
