### PR TITLE
Include model and source in JSON filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ uv run grant.py [<path to pdf> ...] [-f <folder>] -k <k-value>
 Provide either a list of PDF files or use `-f`/`--folder` to recursively search
 for PDFs under the given directory.
 
+The resulting JSON file name now includes the model name from the `MODEL`
+environment variable and the grant source. For example:
+
+```
+grant-gemma3-mygrant.json
+```
+
 ## TypeScript usage
 
 The TypeScript project lives in the `ts/` directory. After installing the dependencies with Yarn, run:

--- a/grant.py
+++ b/grant.py
@@ -9,6 +9,7 @@ from langchain_core.vectorstores import InMemoryVectorStore
 import argparse
 import json
 import os
+import re
 
 
 def main() -> None:
@@ -99,7 +100,16 @@ def main() -> None:
 
     # write to json file
     obj = json.dumps(grant_json, indent=4)
-    with open("grant.json", "w") as outfile:
+    model_name = os.getenv("MODEL", "model")
+    if args.folder:
+        base = os.path.basename(os.path.normpath(args.folder))
+    else:
+        # join pdf file names without extensions
+        names = [os.path.splitext(os.path.basename(f))[0] for f in file_list]
+        base = "_".join(names)
+    base = re.sub(r"[^A-Za-z0-9_-]+", "_", base)
+    filename = f"grant-{model_name}-{base}.json"
+    with open(filename, "w") as outfile:
         outfile.write(obj)
 
 


### PR DESCRIPTION
## Summary
- include `re` import in grant parsing script
- name output JSON file as `grant-<model>-<source>.json`
- document JSON file naming in README

## Testing
- `pytest -q`