### PR TITLE
Include model and source in TS output file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ npx ts-node grant.ts <k-value> [--folder <dir> | <path to pdf> [additional pdfs.
 
 You can provide multiple PDF files for a single grant, or pass `--folder` to load every PDF under a directory recursively. All pages will be loaded together.
 
+The JSON output is saved as `grant_<MODEL>_<source>.json`, where `<MODEL>` comes
+from the `MODEL` environment variable. If `--folder` is used, `<source>` is the
+name of that folder; otherwise it is a list of the provided PDF file names joined
+with underscores.
+
 ## Environment variables
 
 The scripts expect the following variables to be set. Create a `.env` file in the project root and provide values for:

--- a/ts/grant.ts
+++ b/ts/grant.ts
@@ -4,6 +4,9 @@ import { OllamaEmbeddings } from "@langchain/community/embeddings/ollama";
 import { MemoryVectorStore } from "langchain/vectorstores/memory";
 import * as fs from "fs";
 import * as path from "path";
+import * as dotenv from "dotenv";
+
+dotenv.config();
 
 async function collectPdfFiles(dir: string): Promise<string[]> {
   let files: string[] = [];
@@ -93,5 +96,16 @@ async function resolveFilepaths(): Promise<string[]> {
     console.log(JSON.stringify(grant));
   }
 
-  await fs.promises.writeFile("grant.json", JSON.stringify(grant, null, 4));
+  const model = process.env.MODEL || "model";
+  let identifier: string;
+  if (folder) {
+    identifier = path.basename(folder);
+  } else {
+    identifier = filesToParse
+      .map((f) => path.basename(f, path.extname(f)))
+      .join("_");
+  }
+  const safeIdentifier = identifier.replace(/[^a-zA-Z0-9_-]+/g, "_");
+  const outputName = `grant_${model}_${safeIdentifier}.json`;
+  await fs.promises.writeFile(outputName, JSON.stringify(grant, null, 4));
 })();


### PR DESCRIPTION
## Summary
- load `.env` in `grant.ts`
- name the output JSON using the MODEL env var and either the folder or PDF files
- document the new output naming in the README

## Testing
- `pytest -q`