### PR TITLE
Add optional --model arg for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ grant-gemma3-mygrant.json
 The TypeScript project lives in the `ts/` directory. After installing the dependencies with Yarn, run:
 
 ```bash
-npx ts-node grant.ts <k-value> [--folder <dir> | <path to pdf> [additional pdfs...]]
+npx ts-node grant.ts <k-value> [-m <model>] [--folder <dir> | <path to pdf> [additional pdfs...]]
 ```
 
 You can provide multiple PDF files for a single grant, or pass `--folder` to load every PDF under a directory recursively. All pages will be loaded together.

--- a/ts/rag.ts
+++ b/ts/rag.ts
@@ -14,10 +14,15 @@ export async function simSearch(query: string, k: number, vectorStore: MemoryVec
   return context;
 }
 
-export async function retrieveDataFromLlm(question: string, context: string, schema: ReturnType<typeof determineSchema>): Promise<any> {
+export async function retrieveDataFromLlm(
+  question: string,
+  context: string,
+  schema: ReturnType<typeof determineSchema>,
+  modelName?: string
+): Promise<any> {
   dotenv.config();
   const llm = new ChatOpenAI({
-    modelName: process.env.MODEL,
+    modelName: modelName || process.env.MODEL,
     temperature: 0,
     openAIApiKey: process.env.OPENAI_KEY,
     configuration: { baseURL: process.env.OPENAI_BASE_URL }


### PR DESCRIPTION
## Summary
- allow passing `--model` or `-m` to TypeScript grant parser
- set the model via CLI or .env file
- pass optional model name into rag helpers
- document the new argument in README

## Testing
- `pytest -q`
