### PR TITLE
Stop setting MODEL env per request

### DIFF
--- a/api_app.py
+++ b/api_app.py
@@ -16,8 +16,6 @@ load_dotenv()
 
 def process_grant(files: list[str], k: int = 4, model: str | None = None) -> dict:
     """Process one or more PDF files and return grant info as a dict."""
-    if model:
-        os.environ["MODEL"] = model
 
     print("parsing files")
     pages = parse(files)
@@ -47,7 +45,7 @@ def process_grant(files: list[str], k: int = 4, model: str | None = None) -> dic
     for key in llm_queries:
         context = sim_search(vec_queries[key], k, vector_store)
         py_obj = determine_pyobj(key)
-        response = retrieve_data_from_llm(llm_queries[key], context, py_obj)
+        response = retrieve_data_from_llm(llm_queries[key], context, py_obj, model=model)
         grant_json.update(response)
     print("returning json")
     print(grant_json)

--- a/evaluate.py
+++ b/evaluate.py
@@ -49,10 +49,10 @@ def evaluate_prediction(pred: Dict[str, Any], expected: Dict[str, Any], guidelin
         return 0.0
 
 
-def build_output_name(entry: Dict[str, Any]) -> str:
+def build_output_name(entry: Dict[str, Any], model: str | None) -> str:
     """Return the output JSON file name produced by ``grant.py`` for an entry."""
 
-    model_name = os.getenv("MODEL", "model")
+    model_name = model or os.getenv("MODEL", "model")
     if "folder" in entry:
         base = os.path.basename(os.path.normpath(entry["folder"]))
     else:
@@ -92,9 +92,6 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.model:
-        os.environ["MODEL"] = args.model
-
     with open(args.config, "r") as f:
         config = json.load(f)
 
@@ -106,7 +103,7 @@ def main() -> None:
     results = []
     for entry in config:
         runtime = run_grant(entry, args.model)
-        output_file = build_output_name(entry)
+        output_file = build_output_name(entry, args.model)
         with open(output_file, "r") as f:
             predicted = json.load(f)
         with open(entry["expected"], "r") as f:

--- a/grant.py
+++ b/grant.py
@@ -36,8 +36,6 @@ def main() -> None:
     )
     args = argparser.parse_args()
 
-    if args.model:
-        os.environ["MODEL"] = args.model
 
     file_list = []
     if args.folder:
@@ -61,7 +59,7 @@ def main() -> None:
         return
 
     obj = json.dumps(grant_json, indent=4)
-    model_name = os.getenv("MODEL", "model")
+    model_name = args.model or os.getenv("MODEL", "model")
     if args.folder:
         base = os.path.basename(os.path.normpath(args.folder))
     else:

--- a/rag.py
+++ b/rag.py
@@ -29,13 +29,13 @@ from dotenv import load_dotenv
 # downstream functions can access them without needing to load each time.
 load_dotenv()
 
-def retrieve_data_from_llm(question, context, py_obj):
+def retrieve_data_from_llm(question, context, py_obj, model: str | None = None):
     llm = ChatOpenAI(
-        model=os.getenv("MODEL"),
+        model=model or os.getenv("MODEL"),
         temperature=0,
         api_key=os.getenv("OPENAI_KEY"),
         base_url=os.getenv("OPENAI_BASE_URL")
-    )    
+    )
     
     output = JsonOutputParser(pydantic_object=py_obj)
 


### PR DESCRIPTION
## Summary
- avoid setting `os.environ['MODEL']` inside the API
- propagate `model` parameter through `retrieve_data_from_llm`
- adjust CLI tools to derive output names from the argument instead of env

## Testing
- `pytest -q`